### PR TITLE
Update for ceci version 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "deprecated",
-    "pz_rail_base @ git+https://github.com/LSSTDESC/rail_base@ceci2",
+    "pz-rail-base>=1.0.3",
     "pzflow",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "deprecated",
-    "ceci2 @ git+https://github.com/LSSTDESC/rail_base",
+    "pz_rail_base @ git+https://github.com/LSSTDESC/rail_base@ceci2",
     "pzflow",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "deprecated",
-    "ceci2 @ https://github.com/LSSTDESC/rail_base",
+    "ceci2 @ git+https://github.com/LSSTDESC/rail_base",
     "pzflow",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "deprecated",
-    "pz-rail-base",
+    "ceci2 @ https://github.com/LSSTDESC/rail_base",
     "pzflow",
 ]
 

--- a/src/rail/creation/engines/flowEngine.py
+++ b/src/rail/creation/engines/flowEngine.py
@@ -69,12 +69,12 @@ class FlowModeler(Modeler):
         ),
     )
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """Constructor
 
         Does standard Modeler initialization.
         """
-        Modeler.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
 
         # get the columns we are modeling
         phys_cols = self.config.phys_cols
@@ -173,12 +173,12 @@ class FlowCreator(Creator):
     inputs = [("model", FlowHandle)]
     outputs = [("output", PqHandle)]
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """Constructor
 
         Does standard Creator initialization and also gets the `Flow` object
         """
-        Creator.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
 
     def run(self):
         """Run method
@@ -260,12 +260,12 @@ class FlowPosterior(PosteriorCalculator):
     inputs = [("model", FlowHandle), ("input", PqHandle)]
     outputs = [("output", QPHandle)]
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """Constructor
 
         Does standard PosteriorCalculator initialization
         """
-        PosteriorCalculator.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
 
     def run(self):
         """Run method

--- a/src/rail/creation/engines/flowEngine.py
+++ b/src/rail/creation/engines/flowEngine.py
@@ -74,7 +74,7 @@ class FlowModeler(Modeler):
 
         Does standard Modeler initialization.
         """
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
 
         # get the columns we are modeling
         phys_cols = self.config.phys_cols
@@ -178,7 +178,7 @@ class FlowCreator(Creator):
 
         Does standard Creator initialization and also gets the `Flow` object
         """
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
 
     def run(self):
         """Run method
@@ -265,7 +265,7 @@ class FlowPosterior(PosteriorCalculator):
 
         Does standard PosteriorCalculator initialization
         """
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
 
     def run(self):
         """Run method

--- a/src/rail/estimation/algos/pzflow_nf.py
+++ b/src/rail/estimation/algos/pzflow_nf.py
@@ -99,10 +99,10 @@ class PZFlowInformer(CatInformer):
                                                     msg="number flow training epochs"))
 
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """Constructor, build the CatInformer, then do PZFlow specific setup
         """
-        CatInformer.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
         usecols = self.config.column_names.copy()
         allcols = usecols.copy()
         if self.config.include_mag_errors:  # only include errors if option set
@@ -179,8 +179,8 @@ class PZFlowEstimator(CatEstimator):
                                                      msg="name of redshift column"))
 
 
-    def __init__(self, args, comm=None):
-        CatEstimator.__init__(self, args, comm=comm)
+    def __init__(self, args, **kwargs):
+        super().__init__(self, args, **kwargs)
         usecols = self.config.column_names.copy()
         allcols = usecols.copy()
         if self.config.include_mag_errors:  #pragma: no cover

--- a/src/rail/estimation/algos/pzflow_nf.py
+++ b/src/rail/estimation/algos/pzflow_nf.py
@@ -102,7 +102,7 @@ class PZFlowInformer(CatInformer):
     def __init__(self, args, **kwargs):
         """Constructor, build the CatInformer, then do PZFlow specific setup
         """
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         usecols = self.config.column_names.copy()
         allcols = usecols.copy()
         if self.config.include_mag_errors:  # only include errors if option set
@@ -180,7 +180,7 @@ class PZFlowEstimator(CatEstimator):
 
 
     def __init__(self, args, **kwargs):
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         usecols = self.config.column_names.copy()
         allcols = usecols.copy()
         if self.config.include_mag_errors:  #pragma: no cover


### PR DESCRIPTION
This PR updates the constructors of all stage subclasses to work with ceci version 2, in which aliases are specified in the constructor. A similar PR has been opened for each RAIL repo.

The main change is to the the constructors to accept any keywords with **kwargs and pass them to the parent class.

I have also removed any constructors which did not do anything except call the parent class constructor. Since this happens automatically if you omit the constructor, these were redundant.

Finally, in constructors I have changed I have removed hard-coded parent classes in favour of the python3 recommended super() function. If the parent class are changed in the future the constructor will still work.